### PR TITLE
Added github actions to build and publish docker image

### DIFF
--- a/.github/workflows/docker-build-and-release.yml
+++ b/.github/workflows/docker-build-and-release.yml
@@ -34,5 +34,5 @@ jobs:
             OPENCVE_VERSION=${{ env.OPENCVE_VERSION }}
           context: .
           push: true
-          tags: opencve/opencve:v${{ env.OPENCVE_VERSION }}
+          tags: opencve/opencve:${{ env.OPENCVE_VERSION }}
 


### PR DESCRIPTION
This adds a github action to build and publish the docker image to docker hub.

It just requires two secrets to be set on the github repo:
- DOCKERHUB_USERNAME
- DOCKERHUB_TOKEN

The action is only triggered on publish events of a release on the github project.

Having the docker images published to docker hub would be *very* helpful during the devlopment of my helm chart.