### PR TITLE
fix: Fix typo in PostgreSQL data path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,13 +59,13 @@ services:
             POSTGRES_USER: ${POSTGRES_USER:-opencve}
             POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-opencve}
             POSTGRES_DB: opencve
-            PGDATA: /var/lib/postgreqsql/data
+            PGDATA: /var/lib/postgresql/data
         networks:
             - backend
         ports:
             - 127.0.0.1:${POSTGRES_PORT:-5432}:5432
         volumes:
-            - postgres:/var/lib/postgreqsql/data
+            - postgres:/var/lib/postgresql/data
 
 networks:
     backend:


### PR DESCRIPTION
Hello,

This PR fixes a small typo in the PostgreSQL data path:
```
root@26e6f134aae3:/# ls /var/lib/postgre*
postgreqsql postgresql
```

That's not a breaking change, new install and docker-compose down/up still work as this change is only inside the `postgres` container.