### PR TITLE
Upgrade python version from 3.7 to 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-buster as base
+FROM python:3.8-slim-buster as base
 
 # Builder
 FROM base as builder


### PR DESCRIPTION
Following a celery issue (celery/celery#7783) caused by importlib-metadata only for python 3.7, it's a good opportunity to upgrade to python 3.8.

```
$ docker exec webserver python3 --version
Python 3.8.14

$ curl -I http://127.0.0.1:8000/cve
HTTP/1.1 200 OK
Server: gunicorn/20.0.4
Date: Fri, 07 Oct 2022 20:44:52 GMT
Connection: close
Content-Type: text/html; charset=utf-8
Content-Length: 9845
```

This PR fixes opencve/opencve#231