### PR TITLE
Allow image build from specific repository/branch

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 # OPENCVE DOCKER-COMPOSE ENV
+OPENCVE_REPOSITORY=https://github.com/opencve/opencve.git
 OPENCVE_VERSION=1.3.0
 OPENCVE_CONFIG_PATH=./conf/opencve.cfg
 OPENCVE_PORT=8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
 
 WORKDIR /opencve
 
-RUN git clone --depth 1 -b v${OPENCVE_VERSION} "${OPENCVE_REPOSITORY}" .
+RUN git clone --depth 1 -b v${OPENCVE_VERSION} "${OPENCVE_REPOSITORY}" . || git clone --depth 1 -b ${OPENCVE_VERSION} "${OPENCVE_REPOSITORY}" .
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.8-slim-buster as base
 # Builder
 FROM base as builder
 
+ARG OPENCVE_REPOSITORY
 ARG OPENCVE_VERSION
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
@@ -16,7 +17,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
 
 WORKDIR /opencve
 
-RUN git clone https://github.com/opencve/opencve.git . && git checkout tags/v${OPENCVE_VERSION} -b ${OPENCVE_VERSION}
+RUN git clone "${OPENCVE_REPOSITORY}" . && git checkout tags/v${OPENCVE_VERSION} -b ${OPENCVE_VERSION}
 
 WORKDIR /app
 
@@ -33,6 +34,7 @@ COPY run.sh .
 # OpenCVE Image
 FROM base
 
+ARG OPENCVE_REPOSITORY
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 
@@ -41,7 +43,7 @@ ENV https_proxy=$HTTPS_PROXY
 
 LABEL name="opencve"
 LABEL maintainer="dev@opencve.io"
-LABEL url="https://github.com/opencve/opencve"
+LABEL url="${OPENCVE_REPOSITORY}"
 
 RUN apt-get update && apt-get upgrade -y \
     && apt-get clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
 
 WORKDIR /opencve
 
-RUN git clone "${OPENCVE_REPOSITORY}" . && git checkout tags/v${OPENCVE_VERSION} -b ${OPENCVE_VERSION}
+RUN git clone --depth 1 -b v${OPENCVE_VERSION} "${OPENCVE_REPOSITORY}" .
 
 WORKDIR /app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
         build:
             context: .
             args:
+                - OPENCVE_REPOSITORY=${OPENCVE_REPOSITORY}
                 - OPENCVE_VERSION=${OPENCVE_VERSION}
                 - HTTP_PROXY=${HTTP_PROXY:-}
                 - HTTPS_PROXY=${HTTPS_PROXY:-}


### PR DESCRIPTION
It's currently a bit hard to dev using the docker image as the build is not flexible.

This PR allows to easily build the image on a specific repository/branch by specifying them in the docker-compose ENV.

```bash
# Branch config
$ grep VERSION .env
OPENCVE_VERSION=master

# build
$ docker-compose build
redis uses an image, skipping
postgres uses an image, skipping
celery_worker uses an image, skipping
celery_beat uses an image, skipping
Building webserver
Sending build context to Docker daemon  126.5kB
Step 1/32 : FROM python:3.8-slim-buster as base
 ---> 60abb4f18941
.....
Step 11/32 : RUN git clone --depth 1 -b v${OPENCVE_VERSION} "${OPENCVE_REPOSITORY}" . || git clone --depth 1 -b ${OPENCVE_VERSION} "${OPENCVE_REPOSITORY}" .
 ---> Running in a6b687f3471d
Cloning into '.'...
warning: Could not find remote branch vmaster to clone.
fatal: Remote branch vmaster not found in upstream origin
Cloning into '.'...
.....
Successfully built ab3a44b537a4
Successfully tagged opencve:master

# url label
$ docker inspect -f '{{.Config.Labels.url}}' opencve:master
https://github.com/opencve/opencve.git

# Running containers
$ docker ps -a
CONTAINER ID   IMAGE            COMMAND                  CREATED          STATUS          PORTS                                       NAMES
3010dae5638d   opencve:master   "./run.sh celery-wor…"   21 minutes ago   Up 21 minutes                                               celery_worker
76bf8e518796   opencve:master   "./run.sh webserver …"   21 minutes ago   Up 21 minutes   0.0.0.0:8000->8000/tcp, :::8000->8000/tcp   webserver
f8f333dae57f   postgres:11      "docker-entrypoint.s…"   21 minutes ago   Up 21 minutes   127.0.0.1:5432->5432/tcp                    postgres
16f79914aecf   redis:buster     "docker-entrypoint.s…"   21 minutes ago   Up 21 minutes   127.0.0.1:6379->6379/tcp                    redis

# Code from last commit
$ docker exec webserver grep REPORTS_CLEANUP_DAYS ./venv/lib/python3.8/site-packages/opencve/settings.py
    REPORTS_CLEANUP_DAYS = config.getint("core", "reports_cleanup_days", fallback=0)
```

To make it work, the given branch must match docker tag requirement (== no `/`)