### PR TITLE
fix: Update opencve.cfg example with the latest parameters

### DIFF
--- a/conf/opencve.cfg.example
+++ b/conf/opencve.cfg.example
@@ -12,6 +12,7 @@ database_uri = postgresql://opencve:opencve@postgres:5432/opencve
 ; see https://kombu.readthedocs.io/en/latest/userguide/connections.html#connection-urls
 celery_broker_url = redis://redis:6379/0
 celery_result_backend = redis://redis:6379/1
+celery_lock_url = redis://redis:6379/2
 
 ; Display the static frontpage. If False the user will be redirect to the
 ; vulnerabilitites (CVE) page.
@@ -19,6 +20,9 @@ display_welcome = False
 
 ; Display the terms of service page.
 display_terms = False
+
+; Include a HTML analytics code in all pages.
+include_analytics = False
 
 ; Number of items to display in tables.
 cves_per_page = 20
@@ -33,6 +37,10 @@ activities_per_page = 20
 ; Use the werkzeug middleware for reverse proxy
 ; see https://werkzeug.palletsprojects.com/en/1.0.x/middleware/proxy_fix/
 use_reverse_proxy = False
+
+; Cleanup the database by keeping the N last days of reports
+; Set the value to 0 to disable the cleanup
+reports_cleanup_days = 0
 
 ; Display a reCAPTCHA form in register page.
 display_recaptcha = False
@@ -62,6 +70,7 @@ email_from = no-reply@opencve.io
 smtp_server = <your_smtp_server>
 smtp_port = 465
 smtp_use_tls = True
+smtp_use_ssl = False
 smtp_username = <your_username>
 smtp_password = <your_password>
 


### PR DESCRIPTION
Following the release of OpenCVE 1.4.0, the config file example needs to be updated as well.