### PR TITLE
add `linux/arm64` support for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.8-slim-buster as base
 
 # Builder
-FROM base as builder
+ARG BUILDPLATFORM
+FROM --platform=$BUILDPLATFORM base as builder
 
 ARG OPENCVE_REPOSITORY
 ARG OPENCVE_VERSION
@@ -25,14 +26,75 @@ RUN python3 -m venv /app/venv
 
 ENV PATH="/app/venv/bin:$PATH"
 
-RUN python3 -m pip install --upgrade pip
-
-RUN python3 -m pip install /opencve/
+RUN python3 -m pip install --upgrade pip --no-cache-dir
 
 COPY run.sh .
 
+
+# linux/arm64 builder
+ARG BUILDPLATFORM
+FROM --platform=$BUILDPLATFORM builder as builder-arm64
+
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+
+ENV http_proxy=$HTTP_PROXY
+ENV https_proxy=$HTTPS_PROXY
+
+RUN apt-get update && apt-get upgrade -y  && apt-get install -y \
+    libpq-dev \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/ /app/
+
+WORKDIR /app 
+
+ENV PATH="/app/venv/bin:$PATH"
+
+RUN python3 -m pip install psycopg2-binary /opencve --no-cache-dir
+
+
+# linux/amd64 builder
+ARG BUILDPLATFORM
+FROM --platform=$BUILDPLATFORM builder as builder-amd64
+
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+
+ENV http_proxy=$HTTP_PROXY
+ENV https_proxy=$HTTPS_PROXY
+
+WORKDIR /app
+
+ENV PATH="/app/venv/bin:$PATH"
+
+RUN python3 -m pip install /opencve --no-cache-dir
+
+
+# final-arm64
+FROM --platform=linux/arm64 base as final-arm64
+
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+
+ENV http_proxy=$HTTP_PROXY
+ENV https_proxy=$HTTPS_PROXY
+
+RUN apt-get update && apt-get upgrade -y && apt-get install libpq5 -y \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder-arm64 /app/ /app/
+
+
+# final-amd64
+FROM --platform=linux/amd64 base as final-amd64
+COPY --from=builder-amd64 /app/ /app/
+
+ARG TARGETARCH
+FROM final-${TARGETARCH} as final
+
 # OpenCVE Image
-FROM base
+FROM final
 
 ARG OPENCVE_REPOSITORY
 ARG HTTP_PROXY
@@ -49,7 +111,7 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /app/ /app/
+COPY --from=final /app/ /app/
 
 WORKDIR /app
 


### PR DESCRIPTION
add a multi-stage build for both `linux/amd64` and `linux/arm64` paths, use the appropriate arch to build images.

add `libmq-dev` and `gcc` to the `linux/arm64` builder stage, to allow `psycopg2-binary` to be built from source by `pip`.

add `libpq5` to `final-arm64` image so that `psycopg2-binary` is able to use `postgres`.

fix HTTP(S) proxy args in `final-arm64`