### PR TITLE
documentation / docker link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@
 
 This repository contains the files to install and run OpenCVE with Docker, feel free to contribute.
 
-We provide a [documentation](https://docs.opencve.io/installation/docker/) with the details of each step.
+We provide a [documentation](https://docs.opencve.io/v1/installation/docker/) with the details of each step.


### PR DESCRIPTION
correct link for docker install is : https://docs.opencve.io/v1/installation/docker/ (with v1).